### PR TITLE
PAPP-38107: harden Carbon Black Defense V2 request handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2024-2025 Splunk Inc.
+   Copyright (c) 2024-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Carbon Black Defense V2
-Copyright (c) 2024-2025 Splunk Inc.
+Copyright (c) 2024-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **custom_api_connector_id** | optional | password | Custom API Connector ID |
 **custom_api_key** | optional | password | Custom API Key |
 **org_key** | optional | password | Organization Key |
+**verify_server_cert** | optional | boolean | Verify server certificate |
 
 ### Supported Actions
 

--- a/README.md
+++ b/README.md
@@ -953,7 +953,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2024-2025 Splunk Inc.
+# Copyright (c) 2024-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cbdefense.json
+++ b/cbdefense.json
@@ -67,6 +67,12 @@
             "description": "Organization Key",
             "data_type": "password",
             "order": 8
+        },
+        "verify_server_cert": {
+            "description": "Verify server certificate",
+            "data_type": "boolean",
+            "default": true,
+            "order": 9
         }
     },
     "actions": [

--- a/cbdefense.json
+++ b/cbdefense.json
@@ -10,7 +10,7 @@
     "product_name": "Carbon Black Defense",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2024-2025 Splunk Inc.",
+    "license": "Copyright (c) 2024-2026 Splunk Inc.",
     "app_version": "1.0.2",
     "utctime_updated": "2025-09-05T16:29:05.156883Z",
     "package_name": "phantom_carbonblackdefensev2",

--- a/cbdefense_connector.py
+++ b/cbdefense_connector.py
@@ -17,6 +17,7 @@
 # Phantom App imports
 import ipaddress
 import json
+import re
 import time
 
 import phantom.app as phantom
@@ -695,6 +696,9 @@ class CarbonBlackDefenseConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         id = param["id"]
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", id):
+            return action_result.set_status(phantom.APP_ERROR, "Alert ID contains unsupported characters")
+
         ret_val, resp_json = self._make_rest_call(CBD_GET_ALERT_API.format(id, self._org_key), action_result, is_new_api=True)
 
         if phantom.is_fail(ret_val):

--- a/cbdefense_connector.py
+++ b/cbdefense_connector.py
@@ -1,6 +1,6 @@
 # File: cbdefense_connector.py
 #
-# Copyright (c) 2024-2025 Splunk Inc.
+# Copyright (c) 2024-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cbdefense_connector.py
+++ b/cbdefense_connector.py
@@ -262,7 +262,7 @@ class CarbonBlackDefenseConnector(BaseConnector):
                 url,
                 json=data,
                 headers=headers,
-                verify=config.get("verify_server_cert", False),
+                verify=config.get("verify_server_cert", True),
                 params=params,
                 timeout=CBD_DEFAULT_REQUEST_TIMEOUT,
             )

--- a/cbdefense_consts.py
+++ b/cbdefense_consts.py
@@ -1,6 +1,6 @@
 # File: cbdefense_consts.py
 #
-# Copyright (c) 2024-2025 Splunk Inc.
+# Copyright (c) 2024-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cbdefense_get_alert.html
+++ b/cbdefense_get_alert.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: cbdefense_get_alert.html
-  Copyright (c) 2024-2025 Splunk Inc.
+  Copyright (c) 2024-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cbdefense_get_alert.html
+++ b/cbdefense_get_alert.html
@@ -99,14 +99,14 @@ and limitations under the License.
               <tr>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['cb defense alert id'], 'value': '{{ finding_data.id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['cb defense alert id'], 'value': '{{ finding_data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ finding_data.id }}
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
                 </td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['cb defense legacy alert id'], 'value': '{{ finding_data.legacy_alert_id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['cb defense legacy alert id'], 'value': '{{ finding_data.legacy_alert_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ finding_data.legacy_alert_id }}
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
@@ -114,7 +114,7 @@ and limitations under the License.
                 <td>{{ finding_data.type }}</td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['cb defense device id'], 'value': '{{ finding_data.device_id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['cb defense device id'], 'value': '{{ finding_data.device_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ finding_data.device_id }}
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>

--- a/cbdefense_list_policies.html
+++ b/cbdefense_list_policies.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: cbdefense_list_policies.html
-  Copyright (c) 2024-2025 Splunk Inc.
+  Copyright (c) 2024-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cbdefense_list_policies.html
+++ b/cbdefense_list_policies.html
@@ -97,7 +97,7 @@ and limitations under the License.
               <tr>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['cb defense policy id'], 'value': '{{ finding_data.id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['cb defense policy id'], 'value': '{{ finding_data.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ finding_data.id }}
                     &nbsp;
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/cbdefense_views.py
+++ b/cbdefense_views.py
@@ -1,6 +1,6 @@
 # File: cbdefense_views.py
 #
-# Copyright (c) 2024-2025 Splunk Inc.
+# Copyright (c) 2024-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * - Added a server-certificate verification setting that defaults to enabled for all Carbon Black Defense API requests.
+* - Escaped alert identifiers before embedding them in the get-alert widget JavaScript context.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * - Added a server-certificate verification setting that defaults to enabled for all Carbon Black Defense API requests.
 * - Escaped alert identifiers before embedding them in the get-alert widget JavaScript context.
+* - Escaped policy identifiers before embedding them in the list-policies widget JavaScript context.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,6 +1,6 @@
 **Unreleased**
 
-* - Added a server-certificate verification setting that defaults to enabled for all Carbon Black Defense API requests.
-* - Escaped alert identifiers before embedding them in the get-alert widget JavaScript context.
-* - Escaped policy identifiers before embedding them in the list-policies widget JavaScript context.
-* - Restricted alert identifiers to safe URL-path characters before sending Carbon Black Defense API requests.
+* Added a server-certificate verification setting that defaults to enabled for all Carbon Black Defense API requests.
+* Escaped alert identifiers before embedding them in the get-alert widget JavaScript context.
+* Escaped policy identifiers before embedding them in the list-policies widget JavaScript context.
+* Restricted alert identifiers to safe URL-path characters before sending Carbon Black Defense API requests.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Added a server-certificate verification setting that defaults to enabled for all Carbon Black Defense API requests.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * - Added a server-certificate verification setting that defaults to enabled for all Carbon Black Defense API requests.
 * - Escaped alert identifiers before embedding them in the get-alert widget JavaScript context.
 * - Escaped policy identifiers before embedding them in the list-policies widget JavaScript context.
+* - Restricted alert identifiers to safe URL-path characters before sending Carbon Black Defense API requests.


### PR DESCRIPTION
### Bug Fixes

- Enable configurable TLS certificate verification by default to complete the V2 scope explicitly named in PSAAS-30604.
- Escape alert identifiers in the get-alert widget JavaScript context for PSAAS-30774.
- Escape policy identifiers in the list-policies widget JavaScript context for PSAAS-31022.
- Validate alert identifiers before using them as API path segments for PSAAS-30674.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate

### Other information

- Tracking Story: [PAPP-38107](https://splunk.atlassian.net/browse/PAPP-38107)
- Findings: [PSAAS-30604](https://splunk.atlassian.net/browse/PSAAS-30604), [PSAAS-30674](https://splunk.atlassian.net/browse/PSAAS-30674), [PSAAS-30774](https://splunk.atlassian.net/browse/PSAAS-30774), [PSAAS-31022](https://splunk.atlassian.net/browse/PSAAS-31022)
- Queue correction: PSAAS-30604 explicitly names both V1 and V2, so this PR completes the V2 half omitted from the original repo mapping.
- Local validation: full pre-commit suite and Python compile checks passed.
- This PR was created entirely with AI assistance. Written by Codex.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!