### PR TITLE
fix: harden Carbon Black request handling

### DIFF
--- a/cbdefense_connector.py
+++ b/cbdefense_connector.py
@@ -22,7 +22,6 @@ import time
 
 import phantom.app as phantom
 import requests
-from bs4 import BeautifulSoup
 from phantom.action_result import ActionResult
 from phantom.base_connector import BaseConnector
 
@@ -146,56 +145,25 @@ class CarbonBlackDefenseConnector(BaseConnector):
         return RetVal(action_result.set_status(phantom.APP_ERROR, CBD_EMPTY_RESPONSE_NO_HEADER), None)
 
     def _process_html_response(self, response, action_result):
-        # An html response, treat it like an error
-        status_code = response.status_code
-
-        try:
-            soup = BeautifulSoup(response.text, "html.parser")
-            error_text = soup.text
-            split_lines = error_text.split("\n")
-            split_lines = [x.strip() for x in split_lines if x.strip()]
-            error_text = "\n".join(split_lines)
-        except Exception:
-            error_text = CBD_ERROR_TEXT
-
-        message = f"Status Code: {status_code}. Data from server:\n{error_text}\n"
-
-        message = message.replace("{", "{{").replace("}", "}}")
-
-        return RetVal(action_result.set_status(phantom.APP_ERROR, message), None)
+        return RetVal(action_result.set_status(phantom.APP_ERROR, f"Request failed with status code {response.status_code}"), None)
 
     def _process_json_response(self, r, action_result):
         # Try a json parse
         try:
             resp_json = r.json()
-        except Exception as e:
-            return RetVal(
-                action_result.set_status(
-                    phantom.APP_ERROR, f"Unable to parse JSON response. Error: {self._get_error_message_from_exception(e)}"
-                ),
-                None,
-            )
+        except Exception:
+            return RetVal(action_result.set_status(phantom.APP_ERROR, "Unable to parse JSON response"), None)
 
         # Please specify the status codes here
         if 200 <= r.status_code < 399:
             return RetVal(phantom.APP_SUCCESS, resp_json)
 
-        # You should process the error returned in the json
-        if "message" in resp_json:
-            message = resp_json["message"]
-        else:
-            message = "Error from server. Status Code: {} Data from server: {}".format(
-                r.status_code, r.text.replace("{", "{{").replace("}", "}}")
-            )
-
-        return RetVal(action_result.set_status(phantom.APP_ERROR, message), None)
+        return RetVal(action_result.set_status(phantom.APP_ERROR, f"Request failed with status code {r.status_code}"), None)
 
     def _process_response(self, r, action_result):
         # store the r_text in debug data, it will get dumped in the logs if the action fails
         if hasattr(action_result, "add_debug_data"):
             action_result.add_debug_data({"r_status_code": r.status_code})
-            action_result.add_debug_data({"r_text": r.text})
-            action_result.add_debug_data({"r_headers": r.headers})
 
         self._status_code = r.status_code
 
@@ -218,9 +186,7 @@ class CarbonBlackDefenseConnector(BaseConnector):
             return self._process_empty_reponse(r, action_result)
 
         # everything else is actually an error at this point
-        message = "Can't process response from server. Status Code: {} Data from server: {}".format(
-            r.status_code, r.text.replace("{", "{{").replace("}", "}}")
-        )
+        message = f"Can't process response from server. Status Code: {r.status_code}"
 
         return RetVal(action_result.set_status(phantom.APP_ERROR, message), None)
 
@@ -267,11 +233,8 @@ class CarbonBlackDefenseConnector(BaseConnector):
                 params=params,
                 timeout=CBD_DEFAULT_REQUEST_TIMEOUT,
             )
-        except Exception as e:
-            return RetVal(
-                action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {self._get_error_message_from_exception(e)}"),
-                resp_json,
-            )
+        except Exception:
+            return RetVal(action_result.set_status(phantom.APP_ERROR, "Error connecting to server"), resp_json)
 
         return self._process_response(r, action_result)
 

--- a/cbdefense_connector.py
+++ b/cbdefense_connector.py
@@ -114,6 +114,13 @@ class CarbonBlackDefenseConnector(BaseConnector):
 
         return parameter
 
+    def _validate_path_identifier(self, action_result, value, name):
+        value = str(value)
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", value):
+            action_result.set_status(phantom.APP_ERROR, f"{name} contains unsupported characters")
+            return None
+        return value
+
     def _get_error_message_from_exception(self, e):
         """This function is used to get appropriate error message from the exception.
         :param e: Exception object
@@ -300,7 +307,9 @@ class CarbonBlackDefenseConnector(BaseConnector):
     def _handle_delete_policy(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(dict(param)))
-        policy_id = param["id"]
+        policy_id = self._validate_path_identifier(action_result, param["id"], "Policy ID")
+        if policy_id is None:
+            return action_result.get_status()
 
         ret_val, response = self._make_rest_call(CBD_POLICY_API_DEL.format(self._org_key, policy_id), action_result, method="delete")
 
@@ -322,9 +331,11 @@ class CarbonBlackDefenseConnector(BaseConnector):
                 phantom.APP_ERROR, f"Could not parse JSON from rules parameter: {self._get_error_message_from_exception(e)}"
             )
 
-        ret_val, response = self._make_rest_call(
-            CBD_ADD_RULE_API.format(self._org_key, param["id"]), action_result, data=rule_info, method="post"
-        )
+        policy_id = self._validate_path_identifier(action_result, param["id"], "Policy ID")
+        if policy_id is None:
+            return action_result.get_status()
+
+        ret_val, response = self._make_rest_call(CBD_ADD_RULE_API.format(self._org_key, policy_id), action_result, data=rule_info, method="post")
 
         if phantom.is_fail(ret_val):
             return ret_val
@@ -337,10 +348,11 @@ class CarbonBlackDefenseConnector(BaseConnector):
     def _handle_delete_rule(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(dict(param)))
-        rule_id = param["rule_id"]
-        ret_val, response = self._make_rest_call(
-            CBD_DEL_RULE_API.format(self._org_key, param["policy_id"], rule_id), action_result, method="delete"
-        )
+        policy_id = self._validate_path_identifier(action_result, param["policy_id"], "Policy ID")
+        rule_id = self._validate_path_identifier(action_result, param["rule_id"], "Rule ID")
+        if policy_id is None or rule_id is None:
+            return action_result.get_status()
+        ret_val, response = self._make_rest_call(CBD_DEL_RULE_API.format(self._org_key, policy_id, rule_id), action_result, method="delete")
 
         if phantom.is_fail(ret_val):
             return ret_val
@@ -716,7 +728,9 @@ class CarbonBlackDefenseConnector(BaseConnector):
     def _handle_update_policy(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(param))
-        policy_id = param["policy_id"]
+        policy_id = self._validate_path_identifier(action_result, param["policy_id"], "Policy ID")
+        if policy_id is None:
+            return action_result.get_status()
         endpoint = CBD_POLICY_API.format(self._org_key) + "/" + str(policy_id)
 
         try:
@@ -751,7 +765,9 @@ class CarbonBlackDefenseConnector(BaseConnector):
     def _handle_get_policy(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(param))
-        policy_id = param["policy_id"]
+        policy_id = self._validate_path_identifier(action_result, param["policy_id"], "Policy ID")
+        if policy_id is None:
+            return action_result.get_status()
         endpoint = CBD_POLICY_API.format(self._org_key) + "/" + str(policy_id)
         ret_val, response = self._make_rest_call(endpoint, action_result)
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Redact response bodies, headers, and nested transport exception details from persisted error and debug output.
+* Validate policy and rule identifiers before constructing management request paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Redact response bodies, headers, and nested transport exception details from persisted error and debug output.


### PR DESCRIPTION
## Summary

- redact response bodies, headers, and nested transport exception details from persisted error/debug output
- validate policy and rule identifiers before constructing management request paths
- preserve the existing get-alert identifier allowlist across direct and fallback request paths

## Commits and release notes

The transport-redaction and identifier-validation changes are separate functional commits with separate release-note lines. Do not squash this PR; semantic-release relies on commit history.

## Validation context

This is the eligible v2 artifact for [PAPP-38105](https://splunk.atlassian.net/browse/PAPP-38105) ([VULN-94095](https://splunk.atlassian.net/browse/VULN-94095), [VULN-94161](https://splunk.atlassian.net/browse/VULN-94161)) and the v2 portion of [PAPP-38107](https://splunk.atlassian.net/browse/PAPP-38107) / [VULN-93399](https://splunk.atlassian.net/browse/VULN-93399), under [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228). It follows merged v1 PR #28 and merged v2 PR #21.

The explicitly named first-generation handlers for VULN-93399 still require a separate artifact in the first-generation connector; this PR does not claim that half.

## Quality gate

- source compile passed
- `pre-commit run --all-files` passed

Authored by Codex.